### PR TITLE
Fix compile warning

### DIFF
--- a/ipc.c
+++ b/ipc.c
@@ -13,21 +13,6 @@
 #define M_EXIT    "done"
 #define SRV_FLAG  "-producer"
 
-int main(int argc, char *argv[])
-{
-    if (argc < 2)
-    {
-        producer();
-    }
-    else if (argc >= 2 && 0 == strncmp(argv[1], SRV_FLAG, strlen(SRV_FLAG)))
-    {
-        producer();
-    }
-    else
-    {
-        consumer();
-    }
-}
 
 int producer()
 {
@@ -84,4 +69,20 @@ int consumer()
 
     mq_close(mq);
     return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2)
+    {
+        producer();
+    }
+    else if (argc >= 2 && 0 == strncmp(argv[1], SRV_FLAG, strlen(SRV_FLAG)))
+    {
+        producer();
+    }
+    else
+    {
+        consumer();
+    }
 }


### PR DESCRIPTION
Move the main function to the end to avoid these two compile warning.

----
ipc.c: In function ‘main’:
ipc.c:20:9: warning: implicit declaration of function ‘producer’ [-Wimplicit-function-declaration]
         producer();
         ^~~~~~~~
ipc.c:28:9: warning: implicit declaration of function ‘consumer’; did you mean ‘confstr’? [-Wimplicit-function-declaration]
         consumer();
         ^~~~~~~~
